### PR TITLE
Push public Docker images to GitHub Container Registry

### DIFF
--- a/.ci-scripts/release/build-docker-images-on-release.bash
+++ b/.ci-scripts/release/build-docker-images-on-release.bash
@@ -52,12 +52,30 @@ set -o nounset
 # Version: "1.0.0"
 VERSION="${GITHUB_REF/refs\/tags\//}"
 
+## DockerHub
+
+NAME="${GITHUB_REPOSITORY}"
+
 # Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1
-DOCKER_TAG=${GITHUB_REPOSITORY}:"${VERSION}"
+DOCKER_TAG="${NAME}:${VERSION}"
 docker build --pull -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"
 
 # Build and push "release" tag e.g. ponylang/ponyup:release
-DOCKER_TAG=${GITHUB_REPOSITORY}:release
+DOCKER_TAG="${NAME}:release"
+docker build --pull -t "${DOCKER_TAG}" .
+docker push "${DOCKER_TAG}"
+
+## GitHub Container Registry
+
+NAME="ghcr.io/${GITHUB_REPOSITORY}"
+
+# Build and push :VERSION tag e.g. ghcr.io/ponylang/ponyup:0.32.1
+DOCKER_TAG="${NAME}:${VERSION}"
+docker build --pull -t "${DOCKER_TAG}" .
+docker push "${DOCKER_TAG}"
+
+# Build and push "release" tag e.g. ghcr.io/ponylang/ponyup:release
+DOCKER_TAG="${NAME}:release"
 docker build --pull -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"

--- a/.ci-scripts/release/build-latest-docker-images.bash
+++ b/.ci-scripts/release/build-latest-docker-images.bash
@@ -33,7 +33,21 @@ fi
 # allow above so we can display nice error messages for expected unset variables
 set -o nounset
 
+## DockerHub
+
+NAME="${GITHUB_REPOSITORY}"
+
 # Build and push "latest" tag e.g. ponylang/ponyup:latest
-DOCKER_TAG=${GITHUB_REPOSITORY}:latest
+DOCKER_TAG="${NAME}:latest"
+docker build --pull -t "${DOCKER_TAG}" .
+docker push "${DOCKER_TAG}"
+
+
+## GitHub Container Registry
+
+NAME="ghcr.io/${GITHUB_REPOSITORY}"
+
+# Build and push "latest" tag e.g. ponylang/ponyup:latest
+DOCKER_TAG="${NAME}:latest"
 docker build --pull -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"

--- a/.github/workflows/latest-docker-image.yml
+++ b/.github/workflows/latest-docker-image.yml
@@ -11,10 +11,55 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-scripts/release/build-latest-docker-images.bash
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  prune-untagged-images:
+    needs:
+      - build-latest-docker-image
+
+    name: Prune untagged images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune
+        # v4.1.1
+        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        with:
+          package-name: 'ponydoc'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,18 @@ jobs:
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to DockerHub
+        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-scripts/release/build-docker-images-on-release.bash
 


### PR DESCRIPTION
We are transitioning from DockerHub to GitHub Container Registry. As part of this transition, we will have a period of time where we push all images to both registries.

This commit updates ponydoc to push its public images of latest and release builds to GitHub Container Registry and DockerHub.

In addition, it adds a job to run after the latest docker image is pushed to prune old "latest" images that have become "untagged" and shouldn't be being used any longer.